### PR TITLE
Added verticalOffset and parentSelector options to your jQuery-Flex-Vertical-Center plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ This will take the parents height, the elements own height and calculate the dis
 Options
 -------
 
-You can pass one parameter to the plugin, which is the css attribute that the value should be set on. The default is 'margin-top', but you can pass any attribute you would like. Most probably 'padding-top' or 'top'.
+There are 3 parameters you may pass to the plugin, all of which are optional.
+
+- onAttribute - the css attribute that the value should be set on (default: 'margin-top')
+- verticalOffset - the number of pixels to offset the vertical alignment by, ie. 10, "50px", -100 (default: 0)
+- parentSelector - a selector representing the parent to vertically center this element within, ie. ".container" (default: the element's immediate parent)
+
+<!-- comment so codeblock displays properly (codeblocks do not display immediately following lists in markdown syntax) -->
 
 	<script>
 	$(document).ready(function() {

--- a/jquery.flexverticalcenter.js
+++ b/jquery.flexverticalcenter.js
@@ -3,6 +3,8 @@
 * FlexVerticalCenter.js 1.0
 *
 * Copyright 2011, Paul Sprangers http://paulsprangers.com
+* Modifications:
+*  (29/06/2013) added parentSelector and verticalOffset options (Graham Swan http://grahamswan.com)
 * Released under the WTFPL license 
 * http://sam.zoy.org/wtfpl/
 *
@@ -10,17 +12,20 @@
 */
 (function( $ ){
 	
-	$.fn.flexVerticalCenter = function( onAttribute ) {
+	$.fn.flexVerticalCenter = function( onAttribute, verticalOffset, parentSelector ) {
 	
 		return this.each(function(){
 			var $this		= $(this);              // store the object
 			var attribute	= onAttribute || 'margin-top'; // the attribute to put the calculated value on
+			var offset = parseInt(verticalOffset) || 0; // the number of pixels to offset the vertical alignment by
+			var parent_selector = parentSelector || null; // a selector representing the parent to vertically center this element within
         	
 			// recalculate the distance to the top of the element to keep it centered
 			var resizer = function () {
-				// get parent height minus own height and devide by 2
+				var parent_height = (parent_selector) ? $this.parents(parent_selector).first().height() : $this.parent().height();
+				
 				$this.css(
-					attribute, ( ( $this.parent().height() - $this.height() ) / 2 )
+					attribute, ( ( ( parent_height - $this.height() ) / 2 ) + offset )
 				);
 			};
 


### PR DESCRIPTION
While using your plugin on a project of mine, I required 2 new options, so I added them and thought you might want to include them in the plugin.
1. `verticalOffset` - the element I was centering was in a container with a floating navbar, so I had to add a vertical offset to center the element in the space **not** covered by the navbar (default: 0)
2. `parentSelector` - the element needs to be centered within a higher parent container (not the immediate parent), so I added a selector option that will find the specified selector and use the height of that element (default: immediate parent)
