### PR TITLE
[new_options] added verticalOffset and parentSelector options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Simply include this file in your project (after loading jQuery) like this:
 
 Then call the plugin on the element which needs to be vertically centered in it's parent.
 
-	<script>
-	$(document).ready(function() {
-		$('#element-to-be-centered').flexVerticalCenter();
-	});
-	</script>
+  <script>
+  $(document).ready(function() {
+    $('#element-to-be-centered').flexVerticalCenter();
+  });
+  </script>
 
 This will take the parents height, the elements own height and calculate the distance the element should have from the parents top to be vertically centered. This value is applied to the top margin of the element by default.
 
@@ -33,13 +33,13 @@ You can pass an options hash to the plugin.
 
 Examples:
 
-	<script>
-	$(document).ready(function() {
-		$('#element-to-be-centered').flexVerticalCenter();
-		$('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', verticalOffset: '50px' });
-		$('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
-	});
-	</script>
+  <script>
+  $(document).ready(function() {
+    $('#element-to-be-centered').flexVerticalCenter();
+    $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', verticalOffset: '50px' });
+    $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
+  });
+  </script>
 
 
 Non-jQuery version

--- a/index.html
+++ b/index.html
@@ -3,69 +3,69 @@
 <html>
 
 <head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
-	<!--
-	This website was carefully constructed by
-	Interactive Studios
-	http://www.interactivestudios.nl
-	-->
+  <!--
+  This website was carefully constructed by
+  Interactive Studios
+  http://www.interactivestudios.nl
+  -->
 
-	<title>FlexVerticalCenter test</title>
+  <title>FlexVerticalCenter test</title>
 
-	<style>
-		body{
-			margin: 0;
-		}
-		.box {
-			background: #333;
-			height: 300px;
-			margin-bottom: 30px;
-		}
-		.box2 {
-		  background: #ccc;
-		  height: 100px;
-		}
-		p {
-		  width: 20%;
-			margin: 0 auto;
-			color: #fff;
-			font-weight: bold;
-	  }
-	</style>
+  <style>
+    body{
+      margin: 0;
+    }
+    .box {
+      background: #333;
+      height: 300px;
+      margin-bottom: 30px;
+    }
+    .box2 {
+      background: #ccc;
+      height: 100px;
+    }
+    p {
+      width: 20%;
+      margin: 0 auto;
+      color: #fff;
+      font-weight: bold;
+    }
+  </style>
 </head>
 
 <body>
-	<div class="box">
-		<p class="first-item">
-			This box is 20% wide and is always vertically centered within its parent, even if the view port changes (resize your window to see the result).
-		</p>
-	</div>
+  <div class="box">
+    <p class="first-item">
+      This box is 20% wide and is always vertically centered within its parent, even if the view port changes (resize your window to see the result).
+    </p>
+  </div>
 
-	<div class="box">
-		<p class="second-item">
-			This box is 20% wide and is always vertically centered within its parent with a -50px offset, even if the view port changes (resize your window to see the result).
-		</p>
-	</div>
+  <div class="box">
+    <p class="second-item">
+      This box is 20% wide and is always vertically centered within its parent with a -50px offset, even if the view port changes (resize your window to see the result).
+    </p>
+  </div>
 
-	<div class="box parent">
-	  <div class="box2">
-  		<p class="third-item">
-  			This box is 20% wide and is always vertically centered within the specified dark grey parent, even if the view port changes (resize your window to see the result).
-  		</p>
-  	</div>
-	</div>
+  <div class="box parent">
+    <div class="box2">
+      <p class="third-item">
+        This box is 20% wide and is always vertically centered within the specified dark grey parent, even if the view port changes (resize your window to see the result).
+      </p>
+    </div>
+  </div>
 
-	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-	<script src="jquery.flexverticalcenter.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="jquery.flexverticalcenter.js"></script>
 
-	<script>
-		$('.first-item').flexVerticalCenter({ cssAttribute: 'padding-top' });
-		$('.second-item').flexVerticalCenter({ cssAttribute: 'padding-top', verticalOffset: '50px' });
-		$('.third-item').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
-	</script>
+  <script>
+    $('.first-item').flexVerticalCenter({ cssAttribute: 'padding-top' });
+    $('.second-item').flexVerticalCenter({ cssAttribute: 'padding-top', verticalOffset: '50px' });
+    $('.third-item').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
+  </script>
 </body>
 
 </html>

--- a/jquery.flexverticalcenter.js
+++ b/jquery.flexverticalcenter.js
@@ -10,36 +10,36 @@
 */
 (function( $ ){
 
-	$.fn.flexVerticalCenter = function( options ) {
-	  var settings = $.extend({
-	    cssAttribute:   'margin-top', // the attribute to apply the calculated value to
-	    verticalOffset: 0,            // the number of pixels to offset the vertical alignment by
+  $.fn.flexVerticalCenter = function( options ) {
+    var settings = $.extend({
+      cssAttribute:   'margin-top', // the attribute to apply the calculated value to
+      verticalOffset: 0,            // the number of pixels to offset the vertical alignment by
       parentSelector: null          // a selector representing the parent to vertically center this element within
     }, options || {});
 
-		return this.each(function(){
-			var $this		= $(this); // store the object
+    return this.each(function(){
+      var $this   = $(this); // store the object
 
-			// recalculate the distance to the top of the element to keep it centered
-			var resizer = function () {
-				var parentHeight = (settings.parentSelector) ? $this.parents(settings.parentSelector).first().height() : $this.parent().height();
+      // recalculate the distance to the top of the element to keep it centered
+      var resizer = function () {
+        var parentHeight = (settings.parentSelector) ? $this.parents(settings.parentSelector).first().height() : $this.parent().height();
 
-				$this.css(
-					settings.cssAttribute, ( ( ( parentHeight - $this.height() ) / 2 ) + parseInt(settings.verticalOffset) )
-				);
-			};
+        $this.css(
+          settings.cssAttribute, ( ( ( parentHeight - $this.height() ) / 2 ) + parseInt(settings.verticalOffset) )
+        );
+      };
 
-			// Call once to set.
-			resizer();
+      // Call once to set.
+      resizer();
 
-			// Call on resize. Opera debounces their resize by default.
+      // Call on resize. Opera debounces their resize by default.
       $(window).resize(resizer);
 
       // Apply a load event to images within the element so it fires again after an image is loaded
       $this.find('img').load(resizer);
 
-		});
+    });
 
-	};
+  };
 
 })( jQuery );


### PR DESCRIPTION
While using this plugin on a project of mine, I required 2 new options.
1. `verticalOffset` - the element I was centering was in a container with a floating navbar, so I had to add a vertical offset to center the element in the space **not** covered by the navbar (default: 0)
2. `parentSelector` - the element needs to be centered within a higher parent container (not the immediate parent), so I added a selector option that will find the specified selector and use the height of that element (default: immediate parent)

A few notes on the pull request:
- Apologies for all of the whitespace changes—my editor is set to remove trailing space and use soft tabs.
- Turned all options into an options hash (as requested a few months ago)
- Updated the `README` and `index.html` example with the new options

Feel free to shoot any questions my way. Cheers!

Closes #2.
