### PR TITLE
Update resizer function to fire on window load

### DIFF
--- a/jquery.flexverticalcenter.js
+++ b/jquery.flexverticalcenter.js
@@ -33,13 +33,15 @@
         );
       };
 
-      // Call once to set.
-      resizer();
-
       // Call on resize. Opera debounces their resize by default.
       $(window).resize(function () {
           clearTimeout(debounce);
           debounce = setTimeout(resizer, settings.debounceTimeout);
+      });
+
+      // Call once to set after window loads.
+      $(window).load(function () {
+          resizer();
       });
 
       // Apply a load event to images within the element so it fires again after an image is loaded


### PR DESCRIPTION
The resizer function was being called before some of my div content was set which created a weird error and adding extra margin-top to my vertically centered div. I adjusted the code to fire the resize function on window.load and it works perfectly. 
