### PR TITLE
Resize immediately by default. Add option to defer til window.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Usage
 
 Simply include this file in your project (after loading jQuery) like this:
 
-<script defer src="js/jquery.flexverticalcenter.js"></script>
+```<script defer src="js/jquery.flexverticalcenter.js"></script>```
 
 Then call the plugin on the element which needs to be vertically centered in it's parent.
 
+```
   <script>
   $(document).ready(function() {
     $('#element-to-be-centered').flexVerticalCenter();
   });
   </script>
+```
 
 This will take the parents height, the elements own height and calculate the distance the element should have from the parents top to be vertically centered. This value is applied to the top margin of the element by default.
 
@@ -30,9 +32,12 @@ You can pass an options hash to the plugin.
  - `onAttribute` - the css attribute that the value should be set on (default: 'margin-top')
  - `verticalOffset` - the number of pixels to offset the vertical alignment by, ie. 10, "50px", -100 (default: 0)
  - `parentSelector` - a selector representing the parent to vertically center this element within, ie. ".parent" (default: the element's immediate parent)
+ - `debounceTimeout` - in milliseconds, used to rate-limit the vertical centering when resizing the browser window (default: 25)
+ - `deferTilWindowLoad` - if true, no action will be taken until jQuery's window.load event fires. If false, the vertical centering will take place immediately, and then once again on window.load (default: false)
 
 Examples:
 
+```
   <script>
   $(document).ready(function() {
     $('#element-to-be-centered').flexVerticalCenter();
@@ -40,7 +45,7 @@ Examples:
     $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
   });
   </script>
-
+```
 
 Non-jQuery version
 ------------------

--- a/jquery.flexverticalcenter.js
+++ b/jquery.flexverticalcenter.js
@@ -15,7 +15,8 @@
       cssAttribute:   'margin-top', // the attribute to apply the calculated value to
       verticalOffset: 0,            // the number of pixels to offset the vertical alignment by
       parentSelector: null,         // a selector representing the parent to vertically center this element within
-      debounceTimeout: 25           // a default debounce timeout in milliseconds
+      debounceTimeout: 25,          // a default debounce timeout in milliseconds
+      deferTilWindowLoad: false     // if true, nothing will take effect until the $(window).load event
     }, options || {});
 
     return this.each(function(){
@@ -39,13 +40,15 @@
           debounce = setTimeout(resizer, settings.debounceTimeout);
       });
 
-      // Call once to set after window loads.
+      if (!settings.deferTilWindowLoad) {
+        // call it once, immediately.
+        resizer();
+      }
+
+      // Call again to set after window (frames, images, etc) loads.
       $(window).load(function () {
           resizer();
       });
-
-      // Apply a load event to images within the element so it fires again after an image is loaded
-      $this.find('img').load(resizer);
 
     });
 


### PR DESCRIPTION
As I mentioned in the comment on https://github.com/PaulSpr/jQuery-Flex-Vertical-Center/pull/12, acting on window.load by default is a bad idea. The plugin should act immediately when it is called, and if someone wants, they can just call it on window.load.

Note that even when it's called immediately, it should be called again on window.load, since that's when images, frames etc are fully loaded. Also note that calling it on window.load removes the need to do `$this.find('img').load(resizer);`. I've updated the code to reflect this.

I've also added an additional configuration option, `deferTilWindowLoad` which defaults to false, and which can be set true to allow people to call this plugin from their document.ready, but explicitly avoid the immediate resize, and only get the resize on window.load.

I've also made some adjustments to the readme:
- added doco for existing `debounceTimeout` option
- put code samples into backticks so they'll show properly on the GitHub readme page.